### PR TITLE
bgpranking_web package: added Python 3 compatible import

### DIFF
--- a/example/api_web/client/bgpranking_web/__init__.py
+++ b/example/api_web/client/bgpranking_web/__init__.py
@@ -1,1 +1,5 @@
-from api import *
+import sys
+if sys.version_info[0] == 2:
+    from api import *
+else:
+    from .api import *


### PR DESCRIPTION
The import statement in `__init__.py` seems to be the only thing incompatible with Python 3. After the change, it works fine in both Python 2 and 3.
The rest of the package seems to work well in both versions without changes.